### PR TITLE
Fix billard breton website changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@
 							<img src="images/achat.gif" width=100%>
 						</div>
 					</a>
-					<a href="https://www.billards-breton.com/fr/billard.php?ref=monarch&cat=tradition" target="_blank">
+					<a href="https://www.billards-breton.com/table-billard-bois-tradition/monarch/" target="_blank">
 						<div class="row text-center ad">
 							<img src="images/monarch_rect.gif" width=100%>
 						</div>


### PR DESCRIPTION
Billard Bréton m'a informé d'un changement de structure sur leur site web grâce à leur nouveau stagiaire.
Par conséquent, leur gif de promotion redirige vers une page web nommée 404.
Cette correction corrige le problème !